### PR TITLE
allow hiding usernames and ips for reduced load

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Flags:
       --geo.type=""         Type of geoIP database: db, url.
       --geo.url="https://freegeoip.live/json/"  
                             URL for geoIP database API.
+      --metric.hideip       Set this flag to hide IPs in the output and therefore drastically reduce the amount of metrics published.
+      --metric.hideuser     Set this flag to hide user accounts in the output and therefore drastically reduce the amount of metrics published.
       --log.level=info      Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt   Output format of log messages. One of: [logfmt, json]
 ```

--- a/authlog_exporter.go
+++ b/authlog_exporter.go
@@ -54,6 +54,14 @@ func main() {
 			"geo.url",
 			"URL for geoIP database API.",
 		).Default("https://freegeoip.live/json/").String()
+		metricHideIP = kingpin.Flag(
+			"metric.hideip",
+			"Set this flag to hide IPs in the output and therefore drastically reduce the amount of metrics published.",
+		).Bool()
+		metricHideUser = kingpin.Flag(
+			"metric.hideuser",
+			"Set this flag to hide user accounts in the output and therefore drastically reduce the amount of metrics published.",
+		).Bool()
 	)
 	// Set logger config.
 	promlogConfig := &promlog.Config{}
@@ -84,7 +92,7 @@ func main() {
 		"version", version,
 	)
 	// Setup parameters for exporter.
-	promexporter.SetExporterParams(*authlogPath, *promPort, *promPath, *promTLSConfigFile)
+	promexporter.SetExporterParams(*authlogPath, *promPort, *promPath, *promTLSConfigFile, *metricHideIP, *metricHideUser)
 	level.Info(logger).Log(
 		"authlog", *authlogPath,
 		"mgs", "Use port and HTTP endpoint",

--- a/promexporter/exporter.go
+++ b/promexporter/exporter.go
@@ -16,15 +16,19 @@ var (
 	promPort          string
 	promEndpoint      string
 	promTLSConfigPath string
+	hideIP            bool
+	hideUser          bool
 )
 
 // SetExporterParams sets path for 'auth.log' from command line argument 'auth.log',
 // HTTP endpoint parameters from command line arguments 'port', 'endpoint' and 'tlsConfigPath'.
-func SetExporterParams(filePath, port, endpoint, tlsConfigPath string) {
+func SetExporterParams(filePath, port, endpoint, tlsConfigPath string, _hideIP, _hideUser bool) {
 	authlogPath = filePath
 	promPort = port
 	promEndpoint = endpoint
 	promTLSConfigPath = tlsConfigPath
+	hideIP = _hideIP
+	hideUser = _hideUser
 }
 
 // Start runs promhttp endpoind and parsing log process.

--- a/promexporter/exporter.go
+++ b/promexporter/exporter.go
@@ -16,19 +16,19 @@ var (
 	promPort          string
 	promEndpoint      string
 	promTLSConfigPath string
-	hideIP            bool
-	hideUser          bool
+	metricHideIP      bool
+	metricHideUser    bool
 )
 
 // SetExporterParams sets path for 'auth.log' from command line argument 'auth.log',
 // HTTP endpoint parameters from command line arguments 'port', 'endpoint' and 'tlsConfigPath'.
-func SetExporterParams(filePath, port, endpoint, tlsConfigPath string, _hideIP, _hideUser bool) {
+func SetExporterParams(filePath, port, endpoint, tlsConfigPath string, hideIP, hideUser bool) {
 	authlogPath = filePath
 	promPort = port
 	promEndpoint = endpoint
 	promTLSConfigPath = tlsConfigPath
-	hideIP = _hideIP
-	hideUser = _hideUser
+	metricHideIP = hideIP
+	metricHideUser = hideUser
 }
 
 // Start runs promhttp endpoind and parsing log process.

--- a/promexporter/exporter_test.go
+++ b/promexporter/exporter_test.go
@@ -15,8 +15,10 @@ func TestSetExporterParams(t *testing.T) {
 		testPort          = "9991"
 		testEndpoit       = "/metrics"
 		testTLSConfigPath = ""
+		testHideIP        = false
+		testHideUser      = false
 	)
-	SetExporterParams(testLog, testPort, testEndpoit, testTLSConfigPath, false, false)
+	SetExporterParams(testLog, testPort, testEndpoit, testTLSConfigPath, testHideIP, testHideUser)
 	if testLog != authlogPath || testPort != promPort || testEndpoit != promEndpoint || testTLSConfigPath != promTLSConfigPath {
 		t.Errorf("\nVariables do not match,\nlog: %s, want: %s;\nport: %s, want: %s;\nendpoint: %s, want: %s;\nconfig: %s, want: %s",
 			testLog, authlogPath,

--- a/promexporter/exporter_test.go
+++ b/promexporter/exporter_test.go
@@ -16,7 +16,7 @@ func TestSetExporterParams(t *testing.T) {
 		testEndpoit       = "/metrics"
 		testTLSConfigPath = ""
 	)
-	SetExporterParams(testLog, testPort, testEndpoit, testTLSConfigPath)
+	SetExporterParams(testLog, testPort, testEndpoit, testTLSConfigPath, false, false)
 	if testLog != authlogPath || testPort != promPort || testEndpoit != promEndpoint || testTLSConfigPath != promTLSConfigPath {
 		t.Errorf("\nVariables do not match,\nlog: %s, want: %s;\nport: %s, want: %s;\nendpoint: %s, want: %s;\nconfig: %s, want: %s",
 			testLog, authlogPath,

--- a/promexporter/parser.go
+++ b/promexporter/parser.go
@@ -47,8 +47,12 @@ func parseLine(line *tail.Line, logger log.Logger) {
 		return
 	}
 	geoIPData := &geoInfo{}
-	parsedLog.Username = matches["user"]
-	parsedLog.IPAddress = matches["ipAddress"]
+	if !hideUser {
+		parsedLog.Username = matches["user"]
+	}
+	if !hideIP {
+		parsedLog.IPAddress = matches["ipAddress"]
+	}
 	// Get geo information.
 	if geodbIs {
 		if geodbType == "db" {

--- a/promexporter/parser.go
+++ b/promexporter/parser.go
@@ -47,10 +47,10 @@ func parseLine(line *tail.Line, logger log.Logger) {
 		return
 	}
 	geoIPData := &geoInfo{}
-	if !hideUser {
+	if !metricHideUser {
 		parsedLog.Username = matches["user"]
 	}
-	if !hideIP {
+	if !metricHideIP {
 		parsedLog.IPAddress = matches["ipAddress"]
 	}
 	// Get geo information.


### PR DESCRIPTION
I came across the issue that this exporter is producing thousands of metrics per day on my production system since there is basically a new metric for each login attempt. My prometheus can not handle that. 

Therefore this change adds 2 new flags `metric.hideip` and `metric.hideuser` to hide those 2 labels in the metrics which will drastically reduce the amount of metrics but still keeps a usable amount of information. 

Please consider adding this functionality to the application to allow large scale deployments too. 