### PR TITLE
Bump to go1.18.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install golangci-lint and goveralls
         run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/b/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.42.1
+          curl -sfL https://raw.githubusercontent.com/golangci/b/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.50.1
           GO111MODULE=off go get -u github.com/mattn/goveralls
 
       - name: Run linters

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up go 1.17
+      - name: Set up go 1.18
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
 
       - name: Checkout
@@ -24,18 +24,16 @@ jobs:
           go test -v -timeout=100s -covermode=count -coverprofile=$GITHUB_WORKSPACE/coverage.out ./...
         env:
           GOFLAGS: "-mod=vendor"
-          TZ: "Europe/Moscow"
 
       - name: Install golangci-lint and goveralls
         run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.42.1
+          curl -sfL https://raw.githubusercontent.com/golangci/b/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.42.1
           GO111MODULE=off go get -u github.com/mattn/goveralls
 
       - name: Run linters
         run: $GITHUB_WORKSPACE/golangci-lint run
         env:
           GOFLAGS: "-mod=vendor"
-          TZ: "Europe/Moscow"
 
       - name: Submit coverage
         run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverage.out
@@ -100,10 +98,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - name: Set up go 1.17
+      - name: Set up go 1.18
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
 
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,11 @@ jobs:
 
       - name: Install golangci-lint and goveralls
         run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/b/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.50.1
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.50.1
           GO111MODULE=off go get -u github.com/mattn/goveralls
 
       - name: Run linters
-        run: $GITHUB_WORKSPACE/golangci-lint run
+        run: $GITHUB_WORKSPACE/golangci-lint run --out-format=github-actions
         env:
           GOFLAGS: "-mod=vendor"
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,17 +27,14 @@ linters:
     - govet
     - unconvert
     - megacheck
-    - structcheck
     - gas
     - gocyclo
     - dupl
     - misspell
     - unparam
-    - varcheck
-    - deadcode
+    - unused
     - typecheck
     - ineffassign
-    - varcheck
     - stylecheck
     - gochecknoinits
     - exportloopref

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
     main: .
 
 archives:
-  - id: pgbackrest_exporter
+  - id: authlog_exporter
     files:
       - LICENSE
     format: tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.17-alpine AS builder
+FROM golang:1.18-alpine AS builder
 ARG REPO_BUILD_TAG
 WORKDIR /go/src/github.com/woblerr/authlog_exporter
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ remove-service:
 docker-build:
 	@echo "Build $(APP_NAME) docker container"
 	@echo "Version $(BRANCH)-$(GIT_REV)"
-	docker build --pull -f Dockerfile --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) --build-arg BACKREST_VERSION=$(BACKREST_VERSION) -t $(APP_NAME) .
+	docker build --pull -f Dockerfile --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) -t $(APP_NAME) .
 
 .PHONY: docker-run
 docker-run:

--- a/authlog_exporter_test.go
+++ b/authlog_exporter_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"os"
@@ -37,7 +37,7 @@ func TestMain(t *testing.T) {
 		t.Errorf("\nVariables do not match:\n%v\nwant:\n%v", resp.StatusCode, 200)
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Errorf("\nGet error during read resp body:\n%v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/woblerr/authlog_exporter
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-kit/log v0.1.0

--- a/promexporter/exporter.go
+++ b/promexporter/exporter.go
@@ -3,6 +3,7 @@ package promexporter
 import (
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -44,7 +45,10 @@ func Start(logger log.Logger) {
 			</body>
 			</html>`))
 		})
-		server := &http.Server{Addr: ":" + promPort}
+		server := &http.Server{
+			Addr:              ":" + promPort,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
 		if err := web.ListenAndServe(server, promTLSConfigPath, logger); err != nil {
 			level.Error(logger).Log("msg", "Run web endpoint failed", "err", err)
 			os.Exit(1)

--- a/promexporter/geo.go
+++ b/promexporter/geo.go
@@ -2,7 +2,7 @@ package promexporter
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -90,7 +90,7 @@ func getIPDetailsFromURL(returnValues *geoInfo, ipAddres string, logger log.Logg
 		return
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error getting body from GeoIp URL", "err", err)
 		return


### PR DESCRIPTION
* Bump to `go1.18`.
* Bump to golangci-lint `v1.50.1`.
* Fix golangci-lint reported issues.