### PR TITLE
Switch geoip db api url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Flags:
       --geo.lang="en"       Output language format.
       --geo.timeout=2       Timeout in seconds for waiting response from geoIP database API.
       --geo.type=""         Type of geoIP database: db, url.
-      --geo.url="https://freegeoip.live/json/"  
+      --geo.url="https://reallyfreegeoip.org/json/"  
                             URL for geoIP database API.
       --metric.hideip       Set this flag to hide IPs in the output and therefore drastically reduce the amount of metrics published.
       --metric.hideuser     Set this flag to hide user accounts in the output and therefore drastically reduce the amount of metrics published.
@@ -130,7 +130,7 @@ authlog_events_total{cityName="Пекин",countryName="Китай",countyISOCod
 
 #### geoIP database API
 
-To analyze IP addresses location using external API https://freegeoip.live:
+To analyze IP addresses location using external API https://reallyfreegeoip.org:
 
 ```bash
 ./authlog_exporter --geo.type url

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To analyze IP addresses location using external API https://reallyfreegeoip.org:
 ./authlog_exporter --geo.type url
 ```
 
-Be aware that API has a limit of requests per hour. See API documentation.
+Be aware that API may have a limit of requests per hour. See API documentation.
 
 ### Running tests
 

--- a/authlog_exporter.go
+++ b/authlog_exporter.go
@@ -53,7 +53,7 @@ func main() {
 		geodbURL = kingpin.Flag(
 			"geo.url",
 			"URL for geoIP database API.",
-		).Default("https://freegeoip.live/json/").String()
+		).Default("https://reallyfreegeoip.org/json/").String()
 		metricHideIP = kingpin.Flag(
 			"metric.hideip",
 			"Set this flag to hide IPs in the output and therefore drastically reduce the amount of metrics published.",


### PR DESCRIPTION
It looks like the service https://freegeoip.live/ no longer available. 

GeoIP database api setup replaced with https://reallyfreegeoip.org/ , which has a very similar api.