### PR TITLE
Fix hide labels.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: run-test docker-run-test
 .PHONY: test
 test:
 	@echo "Run tests for $(APP_NAME)"
-	go test -mod=vendor -timeout=60s -count 1  ./...
+	TZ="Etc/UTC" go test -mod=vendor -timeout=60s -count 1  ./...
 
 .PHONY: build
 build:

--- a/promexporter/geo.go
+++ b/promexporter/geo.go
@@ -57,16 +57,17 @@ func checkGeoDBFlags(logger log.Logger) {
 	}
 }
 
-func getIPDetailsFromLocalDB(returnValues *geoInfo, ipAddres string, logger log.Logger) {
+func getIPDetailsFromLocalDB(returnValues *geoInfo, ipAddress string, logger log.Logger) {
 	geodb, err := geoip2.Open(geodbPath)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error opening GeoIp database file", "err", err)
 		return
 	}
 	defer geodb.Close()
-	ip := net.ParseIP(ipAddres)
+	level.Debug(logger).Log("msg", "Parse IP", "ip", string(ipAddress))
+	ip := net.ParseIP(ipAddress)
 	if ip == nil {
-		level.Error(logger).Log("msg", "Error parsing ip address", "ip", ipAddres)
+		level.Error(logger).Log("msg", "Error parsing IP address", "ip", ipAddress)
 		return
 	}
 	record, err := geodb.City(ip)
@@ -79,18 +80,20 @@ func getIPDetailsFromLocalDB(returnValues *geoInfo, ipAddres string, logger log.
 	returnValues.cityName = record.City.Names[geoLang]
 }
 
-func getIPDetailsFromURL(returnValues *geoInfo, ipAddres string, logger log.Logger) {
+func getIPDetailsFromURL(returnValues *geoInfo, ipAddress string, logger log.Logger) {
 	// Timeout for get and read response body.
 	client := http.Client{
 		Timeout: time.Duration(geoTimeout) * time.Second,
 	}
-	response, err := client.Get(geoURL + ipAddres)
+	level.Debug(logger).Log("msg", "Get IP details from url", "url", geoURL+ipAddress)
+	response, err := client.Get(geoURL + ipAddress)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error getting GeoIp URL", "err", err)
 		return
 	}
 	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)
+	level.Debug(logger).Log("msg", "Response body", "body", string(body))
 	if err != nil {
 		level.Error(logger).Log("msg", "Error getting body from GeoIp URL", "err", err)
 		return

--- a/promexporter/geo.go
+++ b/promexporter/geo.go
@@ -64,7 +64,7 @@ func getIPDetailsFromLocalDB(returnValues *geoInfo, ipAddress string, logger log
 		return
 	}
 	defer geodb.Close()
-	level.Debug(logger).Log("msg", "Parse IP", "ip", string(ipAddress))
+	level.Debug(logger).Log("msg", "Parse IP", "ip", ipAddress)
 	ip := net.ParseIP(ipAddress)
 	if ip == nil {
 		level.Error(logger).Log("msg", "Error parsing IP address", "ip", ipAddress)

--- a/promexporter/geo_test.go
+++ b/promexporter/geo_test.go
@@ -102,7 +102,7 @@ func TestGetIPDetailsFromURL(t *testing.T) {
 	defer srv.Close()
 	type args struct {
 		returnValues *geoInfo
-		ipAddres     string
+		ipAddress    string
 	}
 
 	tests := []struct {
@@ -123,7 +123,7 @@ func TestGetIPDetailsFromURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			geoURL = tt.testGeoURL
-			getIPDetailsFromURL(tt.args.returnValues, tt.args.ipAddres, logger)
+			getIPDetailsFromURL(tt.args.returnValues, tt.args.ipAddress, logger)
 			if !reflect.DeepEqual(tt.args.returnValues, tt.want) {
 				t.Errorf("\ngetIPDetailsFromURL() =\n%v,\nwant=\n%v", tt.args.returnValues, tt.want)
 			}
@@ -136,7 +136,7 @@ func TestGetIPDetailsFromURLErrors(t *testing.T) {
 	defer srv.Close()
 	type args struct {
 		returnValues *geoInfo
-		ipAddres     string
+		ipAddress    string
 	}
 	reqArgs := args{
 		&geoInfo{"", "", ""},
@@ -174,7 +174,7 @@ func TestGetIPDetailsFromURLErrors(t *testing.T) {
 			geoURL = tt.testGeoURL
 			out := &bytes.Buffer{}
 			lc := log.NewLogfmtLogger(out)
-			getIPDetailsFromURL(tt.args.returnValues, tt.args.ipAddres, lc)
+			getIPDetailsFromURL(tt.args.returnValues, tt.args.ipAddress, lc)
 			if !strings.Contains(out.String(), tt.testText) {
 				t.Errorf("\nVariable do not match:\n%s\nwant:\n%s", tt.testText, out.String())
 			}
@@ -185,7 +185,7 @@ func TestGetIPDetailsFromURLErrors(t *testing.T) {
 func TestGetIPDetailsFromLocalDB(t *testing.T) {
 	type args struct {
 		returnValues *geoInfo
-		ipAddres     string
+		ipAddress    string
 	}
 	geoLang = "en"
 	tests := []struct {
@@ -206,7 +206,7 @@ func TestGetIPDetailsFromLocalDB(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			geodbPath = getFullPath(tt.testGeoFile)
-			getIPDetailsFromLocalDB(tt.args.returnValues, tt.args.ipAddres, logger)
+			getIPDetailsFromLocalDB(tt.args.returnValues, tt.args.ipAddress, logger)
 			if !reflect.DeepEqual(tt.args.returnValues, tt.want) {
 				t.Errorf("\ngetIPDetailsFromURL() =\n%v,\nwant=\n%v", tt.args.returnValues, tt.want)
 			}
@@ -217,7 +217,7 @@ func TestGetIPDetailsFromLocalDB(t *testing.T) {
 func TestGetIPDetailsFromLocalDBErrors(t *testing.T) {
 	type args struct {
 		returnValues *geoInfo
-		ipAddres     string
+		ipAddress    string
 	}
 	tests := []struct {
 		name        string
@@ -239,7 +239,7 @@ func TestGetIPDetailsFromLocalDBErrors(t *testing.T) {
 				"12.123.12.",
 			},
 			"../test_data/geolite2_test.mmdb",
-			"Error parsing ip address",
+			"Error parsing IP address",
 		},
 	}
 	for _, tt := range tests {
@@ -247,7 +247,7 @@ func TestGetIPDetailsFromLocalDBErrors(t *testing.T) {
 			geodbPath = getFullPath(tt.testGeoFile)
 			out := &bytes.Buffer{}
 			lc := log.NewLogfmtLogger(out)
-			getIPDetailsFromLocalDB(tt.args.returnValues, tt.args.ipAddres, lc)
+			getIPDetailsFromLocalDB(tt.args.returnValues, tt.args.ipAddress, lc)
 			if !strings.Contains(out.String(), tt.testText) {
 				t.Errorf("\nVariable do not match:\n%s\nwant:\n%s", tt.testText, out.String())
 			}

--- a/promexporter/parser_test.go
+++ b/promexporter/parser_test.go
@@ -121,3 +121,40 @@ func TestGetMatches(t *testing.T) {
 		})
 	}
 }
+
+func TestHideValue(t *testing.T) {
+	type args struct {
+		value     string
+		boolValue bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"hideTrue",
+			args{
+				value:     "test",
+				boolValue: true,
+			},
+			"",
+		},
+		{
+			"hideFalse",
+			args{
+				value:     "test",
+				boolValue: false,
+			},
+			"test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hideValue(tt.args.boolValue, tt.args.value); got != tt.want {
+				t.Errorf("hideValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/promexporter/parser_test.go
+++ b/promexporter/parser_test.go
@@ -1,9 +1,16 @@
 package promexporter
 
 import (
+	"bytes"
+	"fmt"
 	"reflect"
 	"regexp"
 	"testing"
+	"time"
+
+	"github.com/nxadm/tail"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
 )
 
 func TestGetMatches(t *testing.T) {
@@ -154,6 +161,74 @@ func TestHideValue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := hideValue(tt.args.boolValue, tt.args.value); got != tt.want {
 				t.Errorf("hideValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	type args struct {
+		lineTest    *tail.Line
+		geodbIsTest bool
+	}
+	tests := []struct {
+		name     string
+		args     args
+		testText string
+	}{
+		{
+			"ParseLineExist",
+			args{
+				valToPtr(tail.Line{
+					Text:     "Aug 30 12:02:00 hostname sshd[17917]: User root from 12.123.12.123 not allowed because not listed in AllowUsers",
+					Num:      3,
+					SeekInfo: tail.SeekInfo{Offset: 305, Whence: 0},
+					Time:     time.Unix(1693560000, 0),
+					Err:      nil,
+				}),
+				false,
+			},
+			`# HELP authlog_events_total The total number of auth events.
+# TYPE authlog_events_total counter
+authlog_events_total{cityName="",countryName="",countyISOCode="",eventType="notAllowedUser",ipAddress="12.123.12.123",user="root"} 1
+`,
+		},
+		{
+			"ParseLineNotExist",
+			args{
+				valToPtr(tail.Line{
+					Text:     "Some text",
+					Num:      3,
+					SeekInfo: tail.SeekInfo{Offset: 305, Whence: 0},
+					Time:     time.Unix(1693560000, 0),
+					Err:      nil,
+				}),
+				false,
+			},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authVentsMetric.Reset()
+			geodbIs = tt.args.geodbIsTest
+			parseLine(tt.args.lineTest, logger)
+			reg := prometheus.NewRegistry()
+			reg.MustRegister(
+				authVentsMetric,
+			)
+			metricFamily, err := reg.Gather()
+			if err != nil {
+				fmt.Println(err)
+			}
+			out := &bytes.Buffer{}
+			for _, mf := range metricFamily {
+				if _, err := expfmt.MetricFamilyToText(out, mf); err != nil {
+					panic(err)
+				}
+			}
+			if tt.testText != out.String() {
+				t.Errorf("\nVariables do not match, metrics:\n%s\nwant:\n%s", tt.testText, out.String())
 			}
 		})
 	}


### PR DESCRIPTION
When using flags `--geo.type` and `--metric.hideip` simultaneously, IP wasn't sent to `getIPDetails*` functions. Now it fixed.

A wrapper has been written that hides the values of the user and the IP in the metric, if the `--metric.hideip`  and  `--metric.hideuser` flags are used.

Added debug info in  `getIPDetails*` functions and some other improvements.