### PR TITLE
Switch to go 1.23.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and test
         run: |
@@ -26,15 +26,15 @@ jobs:
           GOFLAGS: "-mod=vendor"
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.2
+          version: v1.62.2
         env:
           TZ: "Etc/UTC"
 
       - name: Install goveralls
         run: |
-          GO111MODULE=off go get -u github.com/mattn/goveralls
+          go install github.com/mattn/goveralls@latest
 
       - name: Submit coverage
         run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverage.out
@@ -42,14 +42,16 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+        run: echo ${BUILDX_PLATFORMS}
+        env:
+          BUILDX_PLATFORMS: ${{ steps.buildx.outputs.platforms }}
 
       - name: Build and push master image to ghcr.io and Docker Hub
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -98,16 +100,16 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env: 
-      goreleaser_version: "v1.24.0"
+      goreleaser_version: "v2.5.0"
     steps:
       - name: Set up go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get ref
         id: vars
@@ -115,7 +117,7 @@ jobs:
           echo ::set-output name=ref::$(echo ${GITHUB_REF} | cut -d'/' -f3)
 
       - name: Check GoReleaser config
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: ${{ env.goreleaser_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up go 1.21
+      - name: Set up go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
         id: go
 
       - name: Checkout
@@ -100,10 +100,10 @@ jobs:
     env: 
       goreleaser_version: "v1.24.0"
     steps:
-      - name: Set up go 1.21
+      - name: Set up go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
         id: go
 
       - name: Checkout

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,16 +2,13 @@ run:
   timeout: 5m
   output:
     format: colored-line-number
-  skip-dirs:
-    - vendor
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   revive:
     confidence: 0.1
-  maligned:
-    suggest-new: true
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -27,12 +24,11 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
+    - staticcheck
     - revive
     - govet
     - unconvert
-    - megacheck
-    - gas
+    - gosec
     - gocyclo
     - dupl
     - misspell
@@ -42,7 +38,7 @@ linters:
     - ineffassign
     - stylecheck
     - gochecknoinits
-    - exportloopref
+    - copyloopvar
     - gocritic
     - nakedret
     - gosimple
@@ -51,6 +47,8 @@ linters:
   disable-all: true
 
 issues:
+  exclude-dirs:
+    - vendor
   exclude-rules:
     - path: _test\.go
       linters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,6 @@
 ---
+version: 2
+
 project_name: authlog_exporter
 
 builds:
@@ -50,4 +52,4 @@ release:
   draft: true
 
 changelog:
-  skip: true
+  disable: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.21-alpine3.20 AS builder
+FROM golang:1.23-alpine3.20 AS builder
 ARG REPO_BUILD_TAG
 WORKDIR /go/src/github.com/woblerr/authlog_exporter
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.21-alpine3.19 AS builder
+FROM golang:1.21-alpine3.20 AS builder
 ARG REPO_BUILD_TAG
 WORKDIR /go/src/github.com/woblerr/authlog_exporter
 COPY . .
@@ -11,7 +11,7 @@ RUN apk update \
         -ldflags "-X main.version=${REPO_BUILD_TAG}" \
         -o authlog_exporter authlog_exporter.go
 
-FROM alpine:3.19
+FROM alpine:3.20
 ARG REPO_BUILD_TAG
 RUN apk add --no-cache --update ca-certificates \
     && rm -rf /var/cache/apk/*

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -1,7 +1,7 @@
-FROM goreleaser/goreleaser:v1.24.0 as builder
+FROM goreleaser/goreleaser:v2.5.0 as builder
 WORKDIR /build
 COPY . /build
-RUN goreleaser release --snapshot --skip-publish --rm-dist
+RUN goreleaser release --snapshot --skip=publish --clean
 
 FROM alpine:3.20
 COPY --from=builder /build/dist/ /dist/

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -3,7 +3,7 @@ WORKDIR /build
 COPY . /build
 RUN goreleaser release --snapshot --skip-publish --rm-dist
 
-FROM alpine
+FROM alpine:3.20
 COPY --from=builder /build/dist/ /dist/
 RUN mkdir -p /artifacts && \
     cp /dist/*.tar.gz /artifacts/ && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/woblerr/authlog_exporter
 
-go 1.21
+go 1.23
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/test_data/Dockerfile.testdb
+++ b/test_data/Dockerfile.testdb
@@ -18,7 +18,7 @@ WORKDIR /build
 COPY --chmod=755 ${SCRIPT_PATH} /build
 RUN /build/create_test_database.pl
 
-FROM alpine
+FROM alpine:3.20
 COPY --from=builder /build/geolite2_test.mmdb /db/
 RUN ls -la /db/*
 CMD ["sleep", "150"]


### PR DESCRIPTION
* Switch to go `1.23`.
* Switch to alpine `3.20`.
* Bump goreleaser to `v2.5.0`.
* Bump golangci-lint  to `v1.62.2`, fix linters.
* Bump actions/setup-go to `v5`.
* Bump actions/checkout to `v4`.
* Bump golangci/golangci-lint-action to `v6`.
* Bump docker/setup-qemu-action to `v3`.
* Bump docker/setup-buildx-action to `v3`.
* Bump goreleaser/goreleaser-action to `v6`.