### PR TITLE
Disable pprof links in landing page.

### DIFF
--- a/promexporter/exporter.go
+++ b/promexporter/exporter.go
@@ -46,6 +46,7 @@ func Start(version string, logger *slog.Logger) {
 				Description: "Prometheus exporter for AuthLog",
 				HeaderColor: "#476b6b",
 				Version:     version,
+				Profiling:   "false",
 				Links: []web.LandingLinks{
 					{
 						Address: webEndpoint,


### PR DESCRIPTION
The pprof functionality is not enabled in the exporter.  This resulted in "404 page not found" links on the landing page.